### PR TITLE
enabled subtask handling, either by Jira Sub-task or Jira issue linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,6 @@ Keep in mind that the following environmental variables need to have a proper va
 |`JIRA_USER`           |True    |None   |Email of the JIRA user the API key belongs to        |
 |`CLICKUP_API_KEY`     |True    |None   |The API key created for accessing ClickUp            |
 |`LOGGING_FORMAT`      |False   |%(asctime)s %(name)-12s:" " %(levelname)-" "8s -  " "%(message)s|The format of the application logs|
-|`LOGGING_LEVEL`       |False   |INFO   |The logging level of the application
+|`LOGGING_LEVEL`       |False   |INFO   |The logging level of the application                 |
+|`SUBTASKS`            |False   |None   |None, "subtask" for Jira sub-task handling (limited to one level of subtasks!), "linked" for Jira linking handling. LINKEDTYPE is mandatory then!|
+|`LINKEDTYPE`          |Depends |None   |Issue linking type name. Outward link should be parent|


### PR DESCRIPTION
Subtask handling was basically disabled, by setting all parents to None in clickup handler.
I assume this is because Jira can only handle one level of sub-tasks, why clickup can work recursively?
(Jira issue type Sub-task cannot contain other Sub-task)

I made this configurable by environment variable:
Default (unset) is to not have sub-task handling at all, 
setting SUBTASKS env variable to "subtask" will use Jira Sub-task style (but you will be responsible to check your data first and ensure that there is only one level if tasks!),
setting to "linked" will use Jira issue linking. In that case, you have to provide a Link type name as env variable LINKEDTYPE as well. 

Also improved ordering of issues, so that parents exist when children are to be created